### PR TITLE
Fix GitHub Actions deprecation by upgrading upload-artifact to v4

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -74,7 +74,7 @@ jobs:
           sed -i 's/ghp_[a-zA-Z0-9]*/[REDACTED]/g' scan_results.txt
 
       - name: Upload scan results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: shai-hulud-scan-results-${{ github.run_number }}
           path: scan_results.txt

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ jobs:
           GITHUB_ORG: ${{ github.repository_owner }}
         run: python3 shai_hulud_github_hunt.py > scan_results.json
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: security-scan-results
           path: scan_results.json

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -395,7 +395,7 @@ jobs:
           sed -i 's/github_pat_[a-zA-Z0-9]*/[REDACTED]/g' scan_results.txt
 
       - name: Upload results securely
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: security-scan-results
           path: scan_results.txt


### PR DESCRIPTION
## Summary
Resolves GitHub Actions failure caused by deprecated `actions/upload-artifact@v3`.

## Problem
Nightly security scans were failing with the error:
> "This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3"

## Changes
Updated `actions/upload-artifact` from v3 to v4 in:
- `.github/workflows/security-scan.yml` - Main security scan workflow
- `README.md` - Documentation examples
- `SECURITY.md` - Security documentation examples

## Benefits
- ✅ Resolves workflow failures
- ✅ Improved upload performance and reliability
- ✅ Better artifact compression
- ✅ No breaking changes - all existing configuration remains compatible

## Testing
- [x] YAML syntax validated
- [x] No remaining v3 references
- [x] Configuration parameters confirmed compatible

## Migration Notes
The v4 upgrade is backward compatible for our use case. All existing parameters (`name`, `path`, `retention-days`) work without modification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)