### PR TITLE
Change default scan target to 'user' for better UX

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,11 +8,11 @@ on:
       target_type:
         description: 'Scan target type'
         required: true
-        default: 'organization'
+        default: 'user'
         type: choice
         options:
-        - organization
         - user
+        - organization
         - repository
       target_name:
         description: 'Target name (org/user/repo)'


### PR DESCRIPTION
Personal accounts are more common than organizations. Updates default and reorders options.