### PR TITLE
Fix target type propagation from workflow to scan script

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Run Shai Hulud security scan
         env:
           GITHUB_TOKEN: ${{ secrets.SECURITY_SCAN_TOKEN }}
-          GITHUB_ORG: ${{ github.event.inputs.target_name || github.repository_owner }}
+          GITHUB_TARGET: ${{ github.event.inputs.target_name || github.repository_owner }}
+          GITHUB_TARGET_TYPE: ${{ github.event.inputs.target_type || 'user' }}
         run: |
           echo "🔍 Starting security scan..."
           python shai_hulud_github_hunt.py > scan_results.txt 2>&1 || echo "⚠️ Scan encountered an error (continuing for artifact upload test)"

--- a/shai_hulud_github_hunt.py
+++ b/shai_hulud_github_hunt.py
@@ -902,9 +902,9 @@ def get_secure_token_input():
 def get_credentials():
   """Get GitHub target and token from environment or user input"""
   # Check environment variables first
-  target = os.getenv("GITHUB_ORG") or os.getenv("GITHUB_USER") or os.getenv("GITHUB_TARGET")
+  target = os.getenv("GITHUB_TARGET") or os.getenv("GITHUB_ORG") or os.getenv("GITHUB_USER")
   token = os.getenv("GITHUB_TOKEN")
-  target_type = None
+  target_type = os.getenv("GITHUB_TARGET_TYPE")
 
   # If no environment variables, get target selection
   if not target:


### PR DESCRIPTION
## Summary
Fixes the issue where user accounts were being treated as organizations, causing 404 errors when scanning.

## Changes
- Workflow now uses `GITHUB_TARGET` and `GITHUB_TARGET_TYPE` environment variables
- Script reads `GITHUB_TARGET_TYPE` from environment to properly handle user vs organization targets
- Ensures correct API endpoint selection based on target type

## Problem Solved
Previously, when `GITHUB_ORG` was set, the script always assumed "organization" type. This caused 404 errors when scanning user accounts like rocklambros.

## Testing
Ready to run manual security scan workflow with:
- target_type: user
- target_name: rocklambros

🤖 Generated with [Claude Code](https://claude.com/claude-code)