### PR TITLE
Fix target type override bug in get_credentials()

### DIFF
--- a/shai_hulud_github_hunt.py
+++ b/shai_hulud_github_hunt.py
@@ -945,8 +945,9 @@ def get_credentials():
             break
         print("Invalid format. Use 'owner/repository-name' format.")
   else:
-    # Environment variable provided - assume organization for backwards compatibility
-    target_type = "organization"
+    # Environment variable provided - use target_type from environment or assume organization for backwards compatibility
+    if not target_type:
+      target_type = "organization"
     print(f"Using target from environment: {target}")
 
   # Get token with improved masking


### PR DESCRIPTION
## Summary
Fixes a bug where the target type from environment variable was being overridden when a target was provided.

## Problem
When `GITHUB_TARGET` was provided via environment, the code unconditionally set `target_type` to "organization", completely overriding any `GITHUB_TARGET_TYPE` value from the environment variable.

## Root Cause
Lines 948-949 in `get_credentials()`:
```python
else:
  # Environment variable provided - assume organization for backwards compatibility
  target_type = "organization"
```

This code ran even when `GITHUB_TARGET_TYPE` was already set at line 907.

## Solution
Only default to "organization" if `target_type` is not already set:
```python
else:
  # Environment variable provided - use target_type from environment or assume organization for backwards compatibility
  if not target_type:
    target_type = "organization"
```

## Impact
- Workflows can now correctly specify `target_type=user` for user account scans
- Fixes 404 errors when scanning user accounts
- Maintains backwards compatibility with existing setups that don't specify target type

🤖 Generated with [Claude Code](https://claude.com/claude-code)